### PR TITLE
WCF operation error code, and auto recovery client no longer throws communication exception

### DIFF
--- a/Question3/InventorySystem.Client/AutoRecoveryClient.cs
+++ b/Question3/InventorySystem.Client/AutoRecoveryClient.cs
@@ -33,7 +33,8 @@ namespace InventorySystem.Client
             {
                 client.Abort();
                 this.internalClient = factory.CreateClient(endpointUri);
-                throw;
+
+                return new OperationResult() { ErrorCode = ErrorCode.Disconnected };
             }
         }
 
@@ -47,7 +48,8 @@ namespace InventorySystem.Client
             {
                 this.internalClient.Abort();
                 this.internalClient = factory.CreateClient(endpointUri);
-                throw;
+
+                return new GetInventoryInfoResult() { ErrorCode = ErrorCode.Disconnected };
             }
         }
 

--- a/Question3/InventorySystem.Contract/OperationResults/ErrorCode.cs
+++ b/Question3/InventorySystem.Contract/OperationResults/ErrorCode.cs
@@ -1,0 +1,14 @@
+﻿namespace InventorySystem.Contract
+{
+    public enum ErrorCode
+    {
+        Success = 0,
+        Disconnected,
+        ProductCodeNotFound,
+        InsufficientQuantity,
+        DuplicateProductCode,
+
+        // Insert new error codes before ErrorCode.Unknown
+        Unknown = 65535,
+    }
+}

--- a/Question3/InventorySystem.Contract/OperationResults/OperationResult.cs
+++ b/Question3/InventorySystem.Contract/OperationResults/OperationResult.cs
@@ -3,10 +3,16 @@
     using System;
     using System.Runtime.Serialization;
 
+
+
     [DataContract]
     public class OperationResult
     {
-        ////TODO: Introduce ErrorCode for error handling.
+        /// <summary>
+        /// Gets or sets the error code of this operation result. Default is ErrorCode.Success.
+        /// </summary>
+        [DataMember]
+        public ErrorCode ErrorCode { get; set; }
 
         /// <summary>
         /// Gets or sets the timestamp indicating when the last update to the inventory system was made.

--- a/Question3/InventorySystem.TestWcfClient/Program.cs
+++ b/Question3/InventorySystem.TestWcfClient/Program.cs
@@ -15,15 +15,8 @@ namespace InventorySystem.TestWcfClient
             {
                 for (int i = 0; i < 100; ++i)
                 {
-                    try
-                    {
-                        var result = await client.GetInventoryInfoAsync().ConfigureAwait(false);
-                        Console.WriteLine(result.LastUpdateTime);
-                    }
-                    catch (Exception ex) when (ex is CommunicationException || ex is TimeoutException)
-                    {
-                        Console.WriteLine(ex.GetType().FullName);
-                    }
+                    var result = await client.CheckUpdateAsync().ConfigureAwait(false);
+                    Console.WriteLine($"CheckUpdateAsync: ErrorCode: {result.ErrorCode}, LastUpdateTime: {result.LastUpdateTime}");
 
                     await Task.Delay(500).ConfigureAwait(false);
                 }


### PR DESCRIPTION
Introduce ErrorCode in WCF operation result, and remove the need to try catch communication exception in AutoRecoveryClient class. Instead Disconnected error code is returned.